### PR TITLE
chore: update and split actions for SDK generation and release

### DIFF
--- a/.github/workflows/generate-and-publish-sdk-sources.yaml
+++ b/.github/workflows/generate-and-publish-sdk-sources.yaml
@@ -1,4 +1,4 @@
-name: Generate and Publish SDK
+name: Generate and Publish SDK Sources
 
 on:
   workflow_dispatch:
@@ -11,23 +11,18 @@ on:
         type: string
       sdk_repo_ref:
         description: |
-          Branch or tag to checkout on the `expediagroup-sdk-core` repository.
+          Branch or tag to checkout on the `expediagroup-java-sdk` repository.
           Leave empty to use the default branch.
         type: string
         default: ''
-      ref:
-        description: |
-          Branch or tag to checkout on the provided repository.
-          Leave empty to use the default branch.
-        type: string
-        default: ''
+
 jobs:
-  generate-and-publish:
+  generate-and-publish-sources:
     uses: ExpediaGroup/expediagroup-java-sdk/.github/workflows/selfserve-full-workflow.yaml@main
     secrets: inherit
     with:
-      name: rapid
+      name: xap
       version: ${{ inputs.version }}
       transformations: "-th --operationIdsToTags"
-      repository:  'ExpediaGroup/xap-java-sdk'
+      repository: 'ExpediaGroup/xap-java-sdk'
       sdk_repo_ref: ${{ inputs.sdk_repo_ref }}

--- a/.github/workflows/release-sdk.yaml
+++ b/.github/workflows/release-sdk.yaml
@@ -1,0 +1,18 @@
+name: Release SDK
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: |
+          Branch to release the SDK from.
+          Defaults to the branch the action is being run from.
+        type: string
+        default: ''
+
+jobs:
+  release-sdk:
+    uses: ExpediaGroup/expediagroup-java-sdk/.github/workflows/selfserve-release-sdk.yaml@main
+    secrets: inherit
+    with:
+      branch: ${{ inputs.branch }}


### PR DESCRIPTION
- **FIX** Rename the product name from `rapid` to `xap` in the generate action.
- Added a new `release-sdk` action to release the SDK from the `code` folder in any branch to Maven Central, utilizing the action from `expediagroup-expediagroup-sdk`.
- Updated the existing `generate-sdk` action by removing unused inputs and renaming variables to reflect the action’s purpose better.

**Prerequisite PR** (must be merged before this): https://github.com/ExpediaGroup/expediagroup-java-sdk/pull/779