### PR TITLE
feat: SDK-1568 expose okhttp client as a configuration for XAP sdk

### DIFF
--- a/.github/workflows/generate-and-publish-sdk-sources.yaml
+++ b/.github/workflows/generate-and-publish-sdk-sources.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   generate-and-publish-sources:
-    uses: ExpediaGroup/expediagroup-java-sdk/.github/workflows/selfserve-full-workflow.yaml@v20241013
+    uses: ExpediaGroup/expediagroup-java-sdk/.github/workflows/selfserve-full-workflow.yaml@dtayeh/SDK-1568
     secrets: inherit
     with:
       name: xap
@@ -20,3 +20,4 @@ jobs:
       transformations: "--headers key --operationIdsToTags"
       repository: 'ExpediaGroup/xap-java-sdk'
       ref: ${{ github.head_ref || github.ref_name }}
+      sdk_repo_ref: "@dtayeh/SDK-1568" 

--- a/.github/workflows/generate-and-publish-sdk-sources.yaml
+++ b/.github/workflows/generate-and-publish-sdk-sources.yaml
@@ -20,3 +20,4 @@ jobs:
       transformations: "--headers key --operationIdsToTags"
       repository: 'ExpediaGroup/xap-java-sdk'
       ref: ${{ github.head_ref || github.ref_name }}
+      sdk_repo_ref: 'dtayeh/SDK-1568'

--- a/.github/workflows/generate-and-publish-sdk-sources.yaml
+++ b/.github/workflows/generate-and-publish-sdk-sources.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   generate-and-publish-sources:
-    uses: ExpediaGroup/expediagroup-java-sdk/.github/workflows/selfserve-full-workflow.yaml@dtayeh/SDK-1568
+    uses: ExpediaGroup/expediagroup-java-sdk/.github/workflows/selfserve-full-workflow.yaml@v20241126
     secrets: inherit
     with:
       name: xap
@@ -20,4 +20,3 @@ jobs:
       transformations: "--headers key --operationIdsToTags"
       repository: 'ExpediaGroup/xap-java-sdk'
       ref: ${{ github.head_ref || github.ref_name }}
-      sdk_repo_ref: 'dtayeh/SDK-1568'

--- a/.github/workflows/generate-and-publish-sdk-sources.yaml
+++ b/.github/workflows/generate-and-publish-sdk-sources.yaml
@@ -20,4 +20,3 @@ jobs:
       transformations: "--headers key --operationIdsToTags"
       repository: 'ExpediaGroup/xap-java-sdk'
       ref: ${{ github.head_ref || github.ref_name }}
-      sdk_repo_ref: "@dtayeh/SDK-1568" 

--- a/customizations/generator/openapi/src/main/resources/templates/expediagroup-sdk/client.mustache
+++ b/customizations/generator/openapi/src/main/resources/templates/expediagroup-sdk/client.mustache
@@ -26,8 +26,23 @@ class {{clientClassname}}Client private constructor(clientConfiguration: XapClie
         )
     }
 
+    class BuilderWithHttpClient() : BaseXapClient.BuilderWithHttpClient<BuilderWithHttpClient>() {
+        override fun build() : {{clientClassname}}Client {
+
+        if (okHttpClient == null) {
+            throw ExpediaGroupConfigurationException(getMissingRequiredConfigurationMessage(ConfigurationName.OKHTTP_CLIENT))
+        }
+
+        return {{clientClassname}}Client(
+                XapClientConfiguration(key, secret, endpoint, null, null, null, maskedLoggingHeaders, maskedLoggingBodyFields, okHttpClient)
+            )
+        }
+    }
+
     companion object {
         @JvmStatic fun builder() = Builder()
+
+        @JvmStatic fun builderWithHttpClient() = BuilderWithHttpClient()
     }
 
     override suspend fun throwServiceException(response: HttpResponse, operationId: String) {

--- a/customizations/generator/openapi/src/main/resources/templates/expediagroup-sdk/imports/core.mustache
+++ b/customizations/generator/openapi/src/main/resources/templates/expediagroup-sdk/imports/core.mustache
@@ -1,7 +1,10 @@
 import com.expediagroup.sdk.core.client.BaseXapClient
 import com.expediagroup.sdk.core.configuration.XapClientConfiguration
+import com.expediagroup.sdk.core.constant.ConfigurationName
 import com.expediagroup.sdk.core.constant.HeaderKey
+import com.expediagroup.sdk.core.constant.provider.ExceptionMessageProvider.getMissingRequiredConfigurationMessage
 import com.expediagroup.sdk.core.model.exception.ExpediaGroupException
+import com.expediagroup.sdk.core.model.exception.client.ExpediaGroupConfigurationException
 import com.expediagroup.sdk.core.model.exception.service.ExpediaGroupServiceException
 import com.expediagroup.sdk.core.model.exception.handle
 import com.expediagroup.sdk.core.model.paging.Paginator


### PR DESCRIPTION
# Situation
Some users of the SDK are interested in getting more control over the underlying httpClient used by the SDK, such as tuning the dispatcher concurrency configs, or injecting interceptors/eventlisteners for monitoring purposes

# Task
Enable users to inject their own okhttp client when configuring the SDK client.

# Action
- Client builder is modified into two builders, one with the shared configs, and another one extended with the timeouts configs.
- All existing base clients extend the Client.ConfigurableHttpBuilder to maintain current behaviour
- A new builder method that takes an okHttpClient as a configuration is added. 
- Users can still configure timeouts on the default existing okhttp client

# Testing
Manual testing by running the XAP examples covering test-cases:
- Configuring timeouts on XAP client
- Configuring a custom okHttpClient, user is unable to configure timeouts outside the httpclient.
- Configuring a client with the existing builder, users are able to set timeouts.

# Results
Users are able to build and inject a custom okhttp client to be used by the SDK for executing requests.