### PR TITLE
chore: migrate to reusable ref docs gh action

### DIFF
--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -2,6 +2,12 @@ name: Deploy Reference Documentation
 
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or tag to deploy reference docs from. Defaults to current branch.'
+        type: string
+        required: false
+        default: ''
 
 permissions:
   id-token: write
@@ -11,5 +17,6 @@ jobs:
     uses: "ExpediaGroup/expediagroup-java-sdk/.github/workflows/generate-ref-docs.yaml@main"
     with:
       buildsystem: 'maven'
+      ref: ${{ inputs.ref != '' && inputs.ref || github.ref }}
     secrets:
       GITHUB_PAT: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/generate-docs-site.yml
+++ b/.github/workflows/generate-docs-site.yml
@@ -8,84 +8,8 @@ permissions:
 
 jobs:
   deploy-reference-docs:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout "main" Branch
-        uses: actions/checkout@v4
-        with:
-          ref: main
-
-      - name: Setup Java 21
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'corretto'
-          java-version: '21'
-
-      - name: Configure Git
-        run: |
-          git config --global user.email "oss@expediagroup.com"
-          git config --global user.name "eg-oss-ci"
-          git fetch --all
-
-      - name: Checkout "gh-pages" Branch
-        run: git checkout gh-pages
-
-      - name: Extract and Store Latest Live Docs Version Number
-        run: echo "LATEST_DOCS_VERSION=$(jq -r '.version' version.json)" >> $GITHUB_ENV
-
-      - name: Move Latest Docs to the "older" Directory (Archiving latest live release)
-        run: |
-          mkdir older/${{ env.LATEST_DOCS_VERSION }} 
-          mv images xap-sdk scripts styles index.html navigation.html not-found-version.html version.json older/${{ env.LATEST_DOCS_VERSION }}
-
-      - name: Move the "older" and "assets" Directories to a Temporary Workspace
-        run: mv older assets ${{ runner.temp }}
-
-      - name: Checkout "main" Branch
-        run: git checkout main
-
-      - name: Generate New Release Reference Docs
-        run: mvn -f code dokka:dokka -Ddokka-old-versions.location=${{ runner.temp }}/older -Ddokka-assets.location=${{ runner.temp }}/assets
-
-      - name: Extract and Store Newly Generated Docs Version Number
-        run: echo "NEW_DOCS_VERSION=$(jq -r '.version' code/target/dokka/version.json)" >> $GITHUB_ENV
-
-      - name: Check the New Release Version
-        run: |
-          for dir in ${{ runner.temp }}/older/*; do
-            if [ -d "$dir" ]; then
-              DIR_NAME=$(basename "$dir")
-              if [ "$DIR_NAME" == "${{ env.NEW_DOCS_VERSION }}" ]; then
-                echo "Error: Reference Docs with version ${{env.NEW_DOCS_VERSION }} already exists."
-                echo "Hint: Make sure to update the project version in the pom.xml file"
-                exit 1
-              fi
-            fi
-          done
-
-      - name: Move the Newly Generated Docs to a Temporary Workspace
-        run: mv code/target/dokka ${{ runner.temp }}/${{ env.NEW_DOCS_VERSION }}
-
-      - name: Checkout "gh-pages" Branch
-        run: git checkout gh-pages
-
-      - name: Cleanup Old Docs from the Repository's Root
-        run: rm -rf code images older xap-sdk scripts styles index.html navigation.html not-found-version.html version.json
-
-      - name: Move Newly Generated Docs to the Repository Root
-        run: mv ${{ runner.temp }}/${{ env.NEW_DOCS_VERSION }}/* .
-
-      - name: Commit the New Release
-        run: |
-          git add .
-          git commit -m "chore: publishing docs for version ${{ env.NEW_DOCS_VERSION }}"
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          commit-message: "chore: publishing docs for version ${{ env.NEW_DOCS_VERSION }}"
-          body: "This PR adds the reference documentation for version ${{ env.NEW_DOCS_VERSION }}."
-          title: "chore: reference docs update for version ${{ env.NEW_DOCS_VERSION }}"
-          branch: "docs-update-${{ env.NEW_DOCS_VERSION }}"
+    uses: "ExpediaGroup/expediagroup-java-sdk/.github/workflows/generate-ref-docs.yaml@main"
+    with:
+      buildsystem: 'maven'
+    secrets:
+      GITHUB_PAT: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
# Situation
Similar to [`ExpediaGroup/lodging-connectivity-java-sdk`](https://github.com/ExpediaGroup/lodging-connectivity-java-sdk/) pull-request [`[152] chore: migrate to reusable ref docs gh action`](https://github.com/ExpediaGroup/lodging-connectivity-java-sdk/pull/152)


# Task
With the newly proposed reusable action in the [`expediagroup-java-sdk`](https://github.com/ExpediaGroup/expediagroup-java-sdk/) repository, specifically in the pr [`[933] chore: add reusable generate reference docs action`](https://github.com/ExpediaGroup/expediagroup-java-sdk/pull/933), different product repositories can use a central GitHub action for generating and deploying reference docs.

Delete the already existing `generate-reference-docs.yaml` action and consume the new action in [`expediagroup-java-sdk`](https://github.com/ExpediaGroup/expediagroup-java-sdk/).

# Action
Deleted the already existing action and modified it to consume the new action.

# Testing
* [run-1](https://github.com/ExpediaGroup/rapid-java-sdk/actions/runs/12734910993)
* [pr-1](https://github.com/ExpediaGroup/rapid-java-sdk/pull/262)

# Results
We now consume the new centralized action.

# Notes
Should not be merged before:
* https://github.com/ExpediaGroup/expediagroup-java-sdk/pull/933
