### PR TITLE
feat: add custom segment param for flight listings

### DIFF
--- a/customizations/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/OpenApiSdkGenerator.kt
+++ b/customizations/generator/openapi/src/main/kotlin/com/expediagroup/sdk/generators/openapi/OpenApiSdkGenerator.kt
@@ -99,6 +99,7 @@ class OpenApiSdkGenerator {
 
                     supportingFiles.add("${namespace.replaceFirstChar(Char::titlecase)}Client.kt")
                     supportingFiles.add("Room.kt")
+                    supportingFiles.add("GetFlightListingsOperationSegmentParam.kt")
 
                     addGlobalProperty(CodegenConstants.SUPPORTING_FILES, supportingFiles.joinToString(","))
                     // addGlobalProperty("debugSupportingFiles", "")
@@ -157,6 +158,14 @@ class OpenApiSdkGenerator {
                                     "xap/room.mustache",
                                     "$packagePath/models/",
                                     "Room.kt"
+                                )
+                            )
+
+                            add(
+                                SupportingFile(
+                                    "xap/get_flight_listings_operation_segment_param.mustache",
+                                    "$packagePath/models/",
+                                    "GetFlightListingsOperationSegmentParam.kt"
                                 )
                             )
                         }

--- a/customizations/generator/openapi/src/main/resources/post-processor/assets/rules/get-flight-listings-operation-params/add-segments-builder-methods.yaml
+++ b/customizations/generator/openapi/src/main/resources/post-processor/assets/rules/get-flight-listings-operation-params/add-segments-builder-methods.yaml
@@ -1,0 +1,8 @@
+rule:
+  kind: 'function_declaration'
+  regex: 'fun build'
+  pattern: '$FUNC'
+  inside:
+    kind: 'class_body'
+    inside:
+      pattern: 'class Builder'

--- a/customizations/generator/openapi/src/main/resources/post-processor/assets/rules/get-flight-listings-operation-params/import-segment.yaml
+++ b/customizations/generator/openapi/src/main/resources/post-processor/assets/rules/get-flight-listings-operation-params/import-segment.yaml
@@ -1,0 +1,4 @@
+rule:
+  kind: "import_header"
+  regex: "OperationParams"
+  pattern: "$HEADER"

--- a/customizations/generator/openapi/src/main/resources/post-processor/assets/rules/get-flight-listings-operation-params/remove-segments-builder-methods.yaml
+++ b/customizations/generator/openapi/src/main/resources/post-processor/assets/rules/get-flight-listings-operation-params/remove-segments-builder-methods.yaml
@@ -1,0 +1,14 @@
+utils:
+  segment-builder:
+    kind: 'function_declaration'
+    regex: 'fun segment*'
+    inside:
+      kind: 'class_body'
+      inside:
+        pattern: 'class Builder'
+rule:
+  any:
+    - matches: segment-builder
+    - kind: 'multiline_comment'
+      precedes:
+        matches: segment-builder

--- a/customizations/generator/openapi/src/main/resources/post-processor/assets/templates/get-flight-listings-operation-params/segments.kt
+++ b/customizations/generator/openapi/src/main/resources/post-processor/assets/templates/get-flight-listings-operation-params/segments.kt
@@ -1,0 +1,47 @@
+fun segment1(segment: GetFlightListingsOperationSegmentParam) = apply {
+  this.segment1Origin = segment.origin
+  this.segment1Destination = segment.destination
+  this.segment1DepartureDate = segment.departureDate
+  this.segment1DepartureStartTime = segment.departureStartTime
+  this.segment1DepartureEndTime = segment.departureEndTime
+}
+
+fun segment2(segment: GetFlightListingsOperationSegmentParam) = apply {
+  this.segment2Origin = segment.origin
+  this.segment2Destination = segment.destination
+  this.segment2DepartureDate = segment.departureDate
+  this.segment2DepartureStartTime = segment.departureStartTime
+  this.segment2DepartureEndTime = segment.departureEndTime
+}
+
+fun segment3(segment: GetFlightListingsOperationSegmentParam) = apply {
+  this.segment3Origin = segment.origin
+  this.segment3Destination = segment.destination
+  this.segment3DepartureDate = segment.departureDate
+  this.segment3DepartureStartTime = segment.departureStartTime
+  this.segment3DepartureEndTime = segment.departureEndTime
+}
+
+fun segment4(segment: GetFlightListingsOperationSegmentParam) = apply {
+  this.segment4Origin = segment.origin
+  this.segment4Destination = segment.destination
+  this.segment4DepartureDate = segment.departureDate
+  this.segment4DepartureStartTime = segment.departureStartTime
+  this.segment4DepartureEndTime = segment.departureEndTime
+}
+
+fun segment5(segment: GetFlightListingsOperationSegmentParam) = apply {
+  this.segment5Origin = segment.origin
+  this.segment5Destination = segment.destination
+  this.segment5DepartureDate = segment.departureDate
+  this.segment5DepartureStartTime = segment.departureStartTime
+  this.segment5DepartureEndTime = segment.departureEndTime
+}
+
+fun segment6(segment: GetFlightListingsOperationSegmentParam) = apply {
+  this.segment6Origin = segment.origin
+  this.segment6Destination = segment.destination
+  this.segment6DepartureDate = segment.departureDate
+  this.segment6DepartureStartTime = segment.departureStartTime
+  this.segment6DepartureEndTime = segment.departureEndTime
+}

--- a/customizations/generator/openapi/src/main/resources/post-processor/src/index.ts
+++ b/customizations/generator/openapi/src/main/resources/post-processor/src/index.ts
@@ -7,6 +7,7 @@ import {VendorLocationDetailsProcessor} from './processors/vendor-location-detai
 import {GetCarsListingsOperationParamsProcessor} from './processors/get-cars-listings-operation-params-processor';
 import {ActivitiesCancellationPolicyProcessor} from './processors/activities-cancellation-policy-processor';
 import {AvailableTimeSlotProcessor} from './processors/available-time-slot-processor';
+import {GetFlightListingsOperationParamsProcessor} from "./processors/get-flight-listings-operation-params-processor";
 
 import * as path from 'path';
 
@@ -41,5 +42,8 @@ switch (fileName) {
     break;
   case 'AvailableTimeSlot':
     new AvailableTimeSlotProcessor().process(filePath);
+    break;
+  case 'GetFlightListingsOperationParams':
+    new GetFlightListingsOperationParamsProcessor().process(filePath);
     break;
 }

--- a/customizations/generator/openapi/src/main/resources/post-processor/src/processors/get-flight-listings-operation-params-processor.ts
+++ b/customizations/generator/openapi/src/main/resources/post-processor/src/processors/get-flight-listings-operation-params-processor.ts
@@ -28,10 +28,10 @@ export class GetFlightListingsOperationParamsProcessor extends Processor {
     const config = this.readRule('import-segment');
 
     return root.findAll(config).map(node => {
-      const room = 'import com.expediagroup.sdk.xap.models.GetFlightListingsOperationSegmentParam';
+      const segment = 'import com.expediagroup.sdk.xap.models.GetFlightListingsOperationSegmentParam';
       const header = node.getMatch('HEADER')?.text();
 
-      return node.replace(`${room}\n${header}`);
+      return node.replace(`${segment}\n${header}`);
     });
   }
 

--- a/customizations/generator/openapi/src/main/resources/post-processor/src/processors/get-flight-listings-operation-params-processor.ts
+++ b/customizations/generator/openapi/src/main/resources/post-processor/src/processors/get-flight-listings-operation-params-processor.ts
@@ -1,0 +1,51 @@
+import * as fs from 'node:fs';
+import {Edit, NapiConfig, SgNode} from '@ast-grep/napi';
+import {Processor} from './processor';
+import {RuleFunction} from './shared.types';
+
+export class GetFlightListingsOperationParamsProcessor extends Processor {
+  rules: RuleFunction[];
+  id: String = 'get-flight-listings-operation-params';
+
+  constructor() {
+    super();
+    this.rules = [
+      this.removeSegmentBuilderMethods,
+      this.importSegment,
+      this.addSegmentsBuilderMethods,
+    ].map(rule => rule.bind(this));
+  }
+
+  removeSegmentBuilderMethods(root: SgNode): Edit[] {
+    const config = this.readRule('remove-segments-builder-methods');
+
+    return root.findAll(config).map(node => {
+      return node.replace('');
+    });
+  }
+
+  importSegment(root: SgNode): Edit[] {
+    const config = this.readRule('import-segment');
+
+    return root.findAll(config).map(node => {
+      const room = 'import com.expediagroup.sdk.xap.models.GetFlightListingsOperationSegmentParam';
+      const header = node.getMatch('HEADER')?.text();
+
+      return node.replace(`${room}\n${header}`);
+    });
+  }
+
+  addSegmentsBuilderMethods(root: SgNode): Edit[] {
+    const config = this.readRule('add-segments-builder-methods');
+
+    const source = fs.readFileSync(
+      './assets/templates/get-flight-listings-operation-params/segments.kt',
+      'utf-8'
+    );
+
+    return root.findAll(config).map(node => {
+      const func = node.getMatch('FUNC')?.text();
+      return node.replace(`${source}\n${func}`);
+    });
+  }
+}

--- a/customizations/generator/openapi/src/main/resources/templates/expediagroup-sdk/xap/get_flight_listings_operation_segment_param.mustache
+++ b/customizations/generator/openapi/src/main/resources/templates/expediagroup-sdk/xap/get_flight_listings_operation_segment_param.mustache
@@ -1,0 +1,41 @@
+package com.expediagroup.sdk.xap.models
+
+data class GetFlightListingsOperationSegmentParam(
+    val origin: String,
+    val destination: String,
+    val departureDate: java.time.LocalDate,
+    val departureStartTime: String?,
+    val departureEndTime: String?
+) {
+    companion object {
+        @JvmStatic
+        fun builder() = Builder()
+    }
+
+    class Builder(
+        private var origin: String? = null,
+        private var destination: String? = null,
+        private var departureDate: java.time.LocalDate? = null,
+        private var departureStartTime: String? = null,
+        private var departureEndTime: String? = null
+    ) {
+        fun origin(origin: String?) = apply { this.origin = origin }
+
+        fun destination(destination: String?) = apply { this.destination = destination }
+
+        fun departureDate(departureDate: java.time.LocalDate?) = apply { this.departureDate = departureDate }
+
+        fun departureStartTime(departureStartTime: String?) = apply { this.departureStartTime = departureStartTime }
+
+        fun departureEndTime(departureEndTime: String?) = apply { this.departureEndTime = departureEndTime }
+
+        fun build(): GetFlightListingsOperationSegmentParam =
+            GetFlightListingsOperationSegmentParam(
+                origin = this.origin!!,
+                destination = this.destination!!,
+                departureDate = this.departureDate!!,
+                departureStartTime = this.departureStartTime,
+                departureEndTime = this.departureEndTime
+            )
+    }
+}


### PR DESCRIPTION
# Situation
<!-- Describe the background or context leading to this change. Include why this work is needed (e.g., a specific problem, user need, or opportunity). What is the current state or issue that prompted this PR? -->
`GetFlightListingsOperationParams` has `segment` params, for which each piece of detail is passed separately.

```
GetFlightListingsOperationParams
   .builder()
   .segment1Origin()
   .segment1Destination()
   .segment1DepartureDate()
   .segment2Origin()
   .segment2Destination()
   .segment2DepartureDate()
   .build()
```

# Task
<!-- Explain the goal or objective of this change. What specifically needs to be achieved to resolve the situation? Clearly define the scope of the task at hand. -->
Add a new custom `segment` data class to hold the details of a segment and pass it to the builder of `GetFlightListingsOperationParams`

# Action
<!-- Summarize the key steps or decisions taken to accomplish the task. Include what changes were made in the codebase, architecture, or process. What actions were implemented to address the task? -->
Parse `GetFlightListingsOperationParams`, and introduce the custom code into it

# Testing
<!-- Describe the testing strategy or approach used to validate the changes. Include any relevant test cases, scenarios, or data used to verify the work. How was the work tested? -->
Generated an SDK with new customization applied, and tested it manually

```
GetFlightListingsOperationParams
   .builder()
   .segment1(Segment.builder().origin().destination().departureDate().build())
   .segment2(Segment.builder().origin().destination().departureDate().build())
   .build()
```
